### PR TITLE
Swap confirmation

### DIFF
--- a/app/assets/stylesheets/components/_cards.scss
+++ b/app/assets/stylesheets/components/_cards.scss
@@ -81,6 +81,10 @@
   color: #52057b;
 }
 
+.list-group-flush a {
+  color: #52057b;
+}
+
 .card-swap {
   border: 2px solid rgba(0,0,0,0.1);
   box-shadow: 3px 6px 10px rgba(0,0,0,0.1);

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -18,8 +18,7 @@ class PagesController < ApplicationController
     @swaps_requests_accepted = Swap.where(user_id: current_user.id, status: 1)
     @swaps_accepted = Swap.joins(:product).where("products.user_id = ?", current_user.id) & Swap.where(status: 1) # accepted
     @swaps_rejected = Swap.where(user_id: current_user.id, status: 2) # rejected
-
-    @swaps = Swap.joins(:product).where("products.user_id = ?", current_user.id) & Swap.where(status: 0)
+    @swaps_requests_for_owner = Swap.joins(:product).where("products.user_id = ?", current_user.id) & Swap.where(status: 0)
   end
 
   def faq

--- a/app/controllers/swaps_controller.rb
+++ b/app/controllers/swaps_controller.rb
@@ -1,5 +1,5 @@
 class SwapsController < ApplicationController
-  before_action :set_swap, only: [:show, :mark_as_rejected, :mark_as_accepted, :mark_as_exchanged]
+  before_action :set_swap, only: [:show, :choose_item, :mark_as_rejected, :mark_as_accepted, :mark_as_exchanged, :mark_as_canceled]
 
   def create
     @product = Product.find(params[:product_id])
@@ -27,10 +27,6 @@ class SwapsController < ApplicationController
     @message = Message.new
   end
 
-  def sent_requests
-    @swaps = Swap.where(user_id: current_user.id)
-  end
-
   def mark_as_rejected
     @product = @swap.product
     @product.status = "available"
@@ -42,12 +38,16 @@ class SwapsController < ApplicationController
   end
 
   def choose_item
-    @swap = Swap.find(params[:id])
+    @swaps = Swap.where(user_id: current_user.id, status: 0)
     @products = @swap.user.products.available
+    @my_products = Product.where(user_id: current_user.id, status: 0)
     @user = @swap.user.first_name
     @swap_product = @swap.product.title
-
-    authorize @swap
+    if @my_products.count >= @swaps.count
+      @swap_possible = true
+    else
+      @swap_possible = false
+    end
   end
 
   def mark_as_accepted
@@ -60,7 +60,6 @@ class SwapsController < ApplicationController
     @swap.status = "accepted"
     @swap.save
     redirect_to my_dashboard_path, notice: "Congrats! You made a swap."
-    authorize @swap
   end
 
   def mark_as_exchanged
@@ -80,11 +79,16 @@ class SwapsController < ApplicationController
     redirect_to my_dashboard_path, notice: "You confirmed receival of the product."
   end
 
-  private
-
-  def swap_params
-    params.require(:swap).permit(:status, :note, :product_id, :user_id)
+  def mark_as_canceled
+    @product = @swap.product
+    @product.status = "available"
+    @product.save
+    @swap.status = "canceled"
+    @swap.save
+    redirect_to my_dashboard_path, notice: "Your swap request has been canceled."
   end
+
+  private
 
   def set_swap
     @swap = Swap.find(params[:id])

--- a/app/controllers/swaps_controller.rb
+++ b/app/controllers/swaps_controller.rb
@@ -1,5 +1,5 @@
 class SwapsController < ApplicationController
-  before_action :set_swap, only: [:show, :mark_as_rejected, :mark_as_accepted]
+  before_action :set_swap, only: [:show, :mark_as_rejected, :mark_as_accepted, :mark_as_exchanged]
 
   def create
     @product = Product.find(params[:product_id])
@@ -61,6 +61,23 @@ class SwapsController < ApplicationController
     @swap.save
     redirect_to my_dashboard_path, notice: "Congrats! You made a swap."
     authorize @swap
+  end
+
+  def mark_as_exchanged
+    @product = @swap.product
+    @other_product = @swap.other_product
+    if current_user.id == @product.user_id
+      @product.status = "exchanged"
+      @product.save
+    else
+      @other_product.status = "exchanged"
+      @other_product.save
+    end
+    if @product.status == @other_product.status
+      @swap.status = "exchanged"
+      @swap.save
+    end
+    redirect_to my_dashboard_path, notice: "You confirmed receival of the product."
   end
 
   private

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,5 +1,5 @@
 class Product < ApplicationRecord
-  enum status: [:available, :onhold, :taken]
+  enum status: [:available, :onhold, :taken, :exchanged]
   validates :title, presence: true
   validates :city, presence: true
   validates :street, presence: true

--- a/app/models/swap.rb
+++ b/app/models/swap.rb
@@ -1,12 +1,10 @@
 class Swap < ApplicationRecord
   belongs_to :user
   belongs_to :product
-
+  belongs_to :other_product, foreign_key: "other_product_id", class_name: "Product", optional: true
   has_many :messages
 
-  belongs_to :other_product, foreign_key: "other_product_id", class_name: "Product", optional: true
-
-  enum status: [:ongoing, :accepted, :rejected, :exchanged]
-
   default_scope { order(updated_at: :desc) }
+
+  enum status: [:ongoing, :accepted, :rejected, :exchanged, :canceled]
 end

--- a/app/policies/swap_policy.rb
+++ b/app/policies/swap_policy.rb
@@ -18,18 +18,22 @@ class SwapPolicy < ApplicationPolicy
   end
 
   def mark_as_rejected?
-    true
+    user == record.user || record.product.user = user
   end
 
   def choose_item?
-    true
+    user == record.user || record.product.user = user
   end
 
   def mark_as_accepted?
-    true
+    user == record.user || record.product.user = user
   end
 
   def mark_as_exchanged?
     user == record.user || record.product.user = user
+  end
+
+  def mark_as_canceled?
+    user == record.user
   end
 end

--- a/app/policies/swap_policy.rb
+++ b/app/policies/swap_policy.rb
@@ -28,4 +28,8 @@ class SwapPolicy < ApplicationPolicy
   def mark_as_accepted?
     true
   end
+
+  def mark_as_exchanged?
+    user == record.user || record.product.user = user
+  end
 end

--- a/app/views/shared/_accepted_swaps.html.erb
+++ b/app/views/shared/_accepted_swaps.html.erb
@@ -28,9 +28,9 @@
         <% if swap.other_product.photo.attached? %>
           <%= cl_image_tag(swap.other_product.photo.key) %>
         <% elsif swap.other_product.category== 'Book' %>
-          <%= image_tag('book-placeholder.png', alt: other_product.title) %>
+          <%= image_tag('book-placeholder.png', alt: swap.other_product.title) %>
         <% else %>
-          <%= image_tag('puzzle-placeholder.png', alt: other_product.title) %>
+          <%= image_tag('puzzle-placeholder.png', alt: swap.other_product.title) %>
         <% end %>
       </div>
       <ul class="list-group list-group-flush">

--- a/app/views/shared/_accepted_swaps.html.erb
+++ b/app/views/shared/_accepted_swaps.html.erb
@@ -1,24 +1,48 @@
 <% @swaps_accepted.each do |swap| %>
-    <div class="card text-white bg-warning mb-3" style="max-width: 18rem;">
-      <div class="card-header">Swap details</div>
+    <div class="col-12 col-sm-12 col-md-4 col-lg-2 card-index card-dashboard">
+      <div class="card-header">You swaped</div>
       <div class="card-body">
-        <h5 class="card-title">You swaped:</h5>
-        <p class="card-text"><%= swap.product.title %></p>
-        <p class="card-text"> FOR </p>
-        <p class="card-text"><%= swap.other_product.title %></p>
+        <% if swap.product.photo.attached? %>
+          <%= cl_image_tag(swap.product.photo.key) %>
+        <% elsif swap.product.category== 'Book' %>
+          <%= image_tag('book-placeholder.png', alt: swap.product.title) %>
+        <% else %>
+          <%= image_tag('puzzle-placeholder.png', alt: swap.product.title) %>
+        <% end %>
       </div>
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item">with <%= swap.other_product.user.first_name %></li>
+        <li class="list-group-item"><%= link_to 'View Details &Chat', swap_path(swap) %></li>
+        <% if swap.product.status == "exchanged" %>
+          <li class="list-group-item">Receival confirmed</li>
+        <% else %>
+          <li class="list-group-item"><%= link_to 'Confirm receival', exchanged_swap_path(swap), method: :patch %></li>
+        <% end %>
+      </ul>
     </div>
 <% end %>
 <% @swaps_requests_accepted.each do |swap| %>
   <div class="col-12 col-sm-12 col-md-4 col-lg-2 card-index card-dashboard">
-  <h3>You swaped: </h3>
-  <div class="card-body">
-    <h5 class="card-title"><%= swap.other_product.title %></h5>
-    <p class="card-text">FOR</p>
-    <h5 class="card-title"><%= swap.product.title %></h5>
-    <p class="card-text">with <%= swap.product.user.first_name %></p>
-  </div>
-  </div>
+      <div class="card-header">You swaped</div>
+      <div class="card-body">
+        <% if swap.other_product.photo.attached? %>
+          <%= cl_image_tag(swap.other_product.photo.key) %>
+        <% elsif swap.other_product.category== 'Book' %>
+          <%= image_tag('book-placeholder.png', alt: other_product.title) %>
+        <% else %>
+          <%= image_tag('puzzle-placeholder.png', alt: other_product.title) %>
+        <% end %>
+      </div>
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item">with <%= swap.product.user.first_name %></li>
+        <li class="list-group-item"><%= link_to 'View Details &Chat', swap_path(swap) %></li>
+        <% if swap.other_product.status == "exchanged" %>
+          <li class="list-group-item">Receival confirmed</li>
+        <% else %>
+          <li class="list-group-item"><%= link_to 'Confirm receival', exchanged_swap_path(swap), method: :patch %></li>
+        <% end %>
+      </ul>
+    </div>
 <% end %>
 
 

--- a/app/views/shared/_choose_item_info.html.erb
+++ b/app/views/shared/_choose_item_info.html.erb
@@ -3,8 +3,7 @@
     Details of the Swap request
   </div>
   <div class="card-body">
-    <h5 class="card-title"><%= @user %> would like to exchange products with you.</h5>
-    <p class="card-text">Choose a one product to proceed with the Swap for <%= @swap_product %></p>
+    <p class="card-text">If you would like to exchange with <strong><%= @user %></strong> for <strong><%= @swap_product %></strong> please choose a one of her products to proceed with the Swap</p>
     <p>If you are not interested</p>
     <%= link_to 'Reject', reject_swap_path(@swap), method: :patch, class: "btn-swap"  %>
   </div>

--- a/app/views/shared/_choose_item_info.html.erb
+++ b/app/views/shared/_choose_item_info.html.erb
@@ -3,7 +3,12 @@
     Details of the Swap request
   </div>
   <div class="card-body">
-    <p class="card-text">If you would like to exchange with <strong><%= @user %></strong> for <strong><%= @swap_product %></strong> please choose a one of her products to proceed with the Swap</p>
+    <% if @swap_possible == false %>
+      <p class="card-text">Sorry, you can not accept this swap request, because you do not have enough products. Please add a product or cancel one of your sent requests.</p>
+      <%= link_to 'Back to my dashboard', my_dashboard_path %>
+    <% else %>
+      <p class="card-text">If you would like to exchange with <strong><%= @user %></strong> for <strong><%= @swap_product %></strong> please choose one of the products below to proceed with the Swap</p>
+    <% end %>
     <p>If you are not interested</p>
     <%= link_to 'Reject', reject_swap_path(@swap), method: :patch, class: "btn-swap"  %>
   </div>

--- a/app/views/shared/_swap_request_for_owner.html.erb
+++ b/app/views/shared/_swap_request_for_owner.html.erb
@@ -1,15 +1,17 @@
 <% @swaps_requests_for_owner.each do |swap| %>
   <div class="col-12 col-sm-12 col-md-4 col-lg-2 card-index card-dashboard">
-    <% if swap.product.photo.attached? %>
-      <%= cl_image_tag(swap.product.photo.key) %>
-    <% elsif swap.product.category== 'Book' %>
-      <%= image_tag('book-placeholder.png', alt: product.title) %>
-    <% else %>
-      <%= image_tag('puzzle-placeholder.png', alt: product.title) %>
-    <% end %>
     <div class="card-body">
-      <p class="card-text">Type: <%= swap.product.category %></p>
-      <p class="card-text"><%= link_to 'Details', choose_item_to_swap_path(swap), class: "btn-swap"  %></p>
+      <% if swap.product.photo.attached? %>
+        <%= cl_image_tag(swap.product.photo.key) %>
+      <% elsif swap.product.category== 'Book' %>
+        <%= image_tag('book-placeholder.png', alt: swap.product.title) %>
+      <% else %>
+        <%= image_tag('puzzle-placeholder.png', alt: swap.product.title) %>
+      <% end %>
     </div>
+    <ul class="list-group list-group-flush">
+      <li class="list-group-item">from <%= swap.product.user.first_name %></li>
+      <li class="list-group-item"><%= link_to 'Details', choose_item_to_swap_path(swap) %></li>
+    </ul>
   </div>
 <% end %>

--- a/app/views/shared/_swap_request_for_owner.html.erb
+++ b/app/views/shared/_swap_request_for_owner.html.erb
@@ -1,4 +1,4 @@
-<% @swaps.each do |swap| %>
+<% @swaps_requests_for_owner.each do |swap| %>
   <div class="col-12 col-sm-12 col-md-4 col-lg-2 card-index card-dashboard">
     <% if swap.product.photo.attached? %>
       <%= cl_image_tag(swap.product.photo.key) %>

--- a/app/views/shared/_swaps_requests.html.erb
+++ b/app/views/shared/_swaps_requests.html.erb
@@ -3,15 +3,19 @@
     <% if swap.product.photo.attached? %>
       <%= cl_image_tag(swap.product.photo.key) %>
     <% elsif swap.product.category== 'Book' %>
-      <%= image_tag('book-placeholder.png', alt: product.title) %>
+      <%= image_tag('book-placeholder.png', alt: swap.product.title) %>
     <% else %>
-      <%= image_tag('puzzle-placeholder.png', alt: product.title) %>
+      <%= image_tag('puzzle-placeholder.png', alt: swap.product.title) %>
     <% end %>
     <div class="card-body">
       <h5 class="card-title"><%= swap.product.title %></h5>
       <p class="card-text">Type: <%= swap.product.category %></p>
       <p class="card-text"><i class="fas fa-map-marker-alt"></i> <%= swap.product.city %></p>
+      <% if policy(swap).mark_as_canceled? %>
+        <%= link_to canceled_swap_path(swap), method: :patch do %>
+          <i class="far fa-trash-alt"></i>
+        <% end %>
+      <% end %>
     </div>
   </div>
 <% end %>
-

--- a/app/views/swaps/choose_item.html.erb
+++ b/app/views/swaps/choose_item.html.erb
@@ -3,37 +3,39 @@
     <%= render 'shared/choose_item_info' %>
   </div>
 
-  <%= simple_form_for @swap, url: accept_swap_path, method: :patch, wrapper: :inline_form, html: {class: 'form-inline'} do |f| %>
-    <div class="row mt-2">
-      <% @products.each do |product| %>
-        <div class="col-12 col-sm-12 col-md-4 col-lg-2 card-index card-dashboard">
-          <% if product.photo.attached? %>
-            <%= cl_image_tag(product.photo.key) %>
-          <% elsif product.category== 'Book' %>
-            <%= image_tag('book-placeholder.png', alt: product.title) %>
-          <% else %>
-            <%= image_tag('puzzle-placeholder.png', alt: product.title) %>
-          <% end %>
-          <div class="card-body">
-            <h5 class="card-title"><%= product.title %></h5>
-            <p class="card-text">Type: <%= product.category %></p>
-            <p class="card-text"><i class="fas fa-map-marker-alt"></i> <%= product.city %></p>
-            <p class="card-text">
-              <div class="form-check ">
-                <input class="form-check-input" type="radio" name="other_product_id" id="other_product<%=  product.id %>" value="<%=  product.id %>" checked>
-                <label class="form-check-label" for="exampleRadios1">
-                  Choose
-                </label>
-              </div>
-            </p>
+<% if @swap_possible == true %>
+    <%= simple_form_for @swap, url: accept_swap_path, method: :patch, wrapper: :inline_form, html: {class: 'form-inline'} do |f| %>
+      <div class="row mt-2">
+        <% @products.each do |product| %>
+          <div class="col-12 col-sm-12 col-md-4 col-lg-2 card-index card-dashboard">
+            <% if product.photo.attached? %>
+              <%= cl_image_tag(product.photo.key) %>
+            <% elsif product.category== 'Book' %>
+              <%= image_tag('book-placeholder.png', alt: product.title) %>
+            <% else %>
+              <%= image_tag('puzzle-placeholder.png', alt: product.title) %>
+            <% end %>
+            <div class="card-body">
+              <h5 class="card-title"><%= product.title %></h5>
+              <p class="card-text">Type: <%= product.category %></p>
+              <p class="card-text"><i class="fas fa-map-marker-alt"></i> <%= product.city %></p>
+              <p class="card-text">
+                <div class="form-check ">
+                  <input class="form-check-input" type="radio" name="other_product_id" id="other_product<%=  product.id %>" value="<%=  product.id %>" checked>
+                  <label class="form-check-label" for="exampleRadios1">
+                    Choose
+                  </label>
+                </div>
+              </p>
+            </div>
           </div>
-        </div>
-      <% end %>
-    </div>
-    <div class="col-lg-4 col-md-4 col-sm-4 container justify-content-center">
-      <div class="form-actions">
-        <%= f.button :submit, "Accept", class: "btn-swap" %>
+        <% end %>
       </div>
-    </div>
+      <div class="col-lg-4 col-md-4 col-sm-4 container justify-content-center">
+        <div class="form-actions">
+          <%= f.button :submit, "Accept", class: "btn-swap" %>
+        </div>
+      </div>
+    <% end %>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   patch 'swaps/:id/reject', to: 'swaps#mark_as_rejected', as: :reject_swap
   get 'swaps/:id/choose_item', to: 'swaps#choose_item', as: :choose_item_to_swap
   patch 'swaps/:id/accept', to: 'swaps#mark_as_accepted', as: :accept_swap
+  patch 'swaps/:id/exchanged', to: 'swaps#mark_as_exchanged', as: :exchanged_swap
 
   get 'faq', to: 'pages#faq'
   get 'team', to: 'pages#team'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get 'swaps/:id/choose_item', to: 'swaps#choose_item', as: :choose_item_to_swap
   patch 'swaps/:id/accept', to: 'swaps#mark_as_accepted', as: :accept_swap
   patch 'swaps/:id/exchanged', to: 'swaps#mark_as_exchanged', as: :exchanged_swap
+  patch 'swaps/:id/canceled', to: 'swaps#mark_as_canceled', as: :canceled_swap
 
   get 'faq', to: 'pages#faq'
   get 'team', to: 'pages#team'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,9 +57,9 @@ ActiveRecord::Schema.define(version: 2021_04_29_153111) do
     t.integer "status", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "user_id", null: false
     t.float "latitude"
     t.float "longitude"
+    t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_products_on_user_id"
   end
 


### PR DESCRIPTION
I added a confirmation to the acceped swaps, I managed to this for both users and the swap info disappear after the confirmation from both parties involved.
![Screenshot 2021-04-30 at 22 44 02](https://user-images.githubusercontent.com/78602093/116814723-96c79280-ab5a-11eb-883b-ce7b1d7d6f46.png)

I also realised that we also have to block accept option for people, who sent a request, cause they have to have an available product or just cancle the request.

https://user-images.githubusercontent.com/78602093/116814893-41d84c00-ab5b-11eb-8c33-5fc7e444e44e.mov




